### PR TITLE
DTSPO-24907 - add additional vnets and subnet

### DIFF
--- a/components/landing/data-landing-zone.tf
+++ b/components/landing/data-landing-zone.tf
@@ -1,5 +1,5 @@
 module "data_landing_zone" {
-  source = "github.com/hmcts/terraform-module-data-landing-zone?ref=feat%2Fbastion"
+  source = "github.com/hmcts/terraform-module-data-landing-zone?ref=DTSPO-24907/auto-pause-disabled-2"
 
   for_each = var.landing_zones
 

--- a/components/landing/data-landing-zone.tf
+++ b/components/landing/data-landing-zone.tf
@@ -1,5 +1,5 @@
 module "data_landing_zone" {
-  source = "github.com/hmcts/terraform-module-data-landing-zone?ref=DTSPO-24907/auto-pause-disabled-2"
+  source = "github.com/hmcts/terraform-module-data-landing-zone?ref=feat%2Fbastion"
 
   for_each = var.landing_zones
 

--- a/components/landing/inputs-required.tf
+++ b/components/landing/inputs-required.tf
@@ -60,7 +60,7 @@ variable "landing_zones" {
       description                                = optional(string)
     })))
     additional_vnet_address_space = optional(list(string), [])
-    additional_subnets = map(object({
+    additional_subnets = optional(map(object({
       name_override     = optional(string)
       address_prefixes  = list(string)
       service_endpoints = optional(list(string), [])
@@ -68,7 +68,7 @@ variable "landing_zones" {
         service_name = string,
         actions      = optional(list(string), [])
       })))
-    }))
+    })))
   }))
 }
 

--- a/components/landing/inputs-required.tf
+++ b/components/landing/inputs-required.tf
@@ -60,6 +60,15 @@ variable "landing_zones" {
       description                                = optional(string)
     })))
     additional_vnet_address_space = optional(list(string), [])
+    additional_subnets = optional(map(object({
+      name              = string
+      address_space     = list(string)
+      service_endpoints = optional(list(string), [])
+      delegations = optional(list(object({
+        name         = string
+        service_name = string
+      })), [])
+    })), {})
   }))
 }
 

--- a/components/landing/inputs-required.tf
+++ b/components/landing/inputs-required.tf
@@ -62,12 +62,12 @@ variable "landing_zones" {
     additional_vnet_address_space = optional(list(string), [])
     additional_subnets = optional(map(object({
       name_override     = optional(string)
-      address_prefixes  = optional(list(string))
+      address_prefixes  = list(string)
       service_endpoints = optional(list(string), [])
-      delegations = optional(map(object({
+      delegations = optional(object({
         service_name = string,
         actions      = optional(list(string), [])
-      })))
+      }))
     })))
   }))
 }

--- a/components/landing/inputs-required.tf
+++ b/components/landing/inputs-required.tf
@@ -60,15 +60,15 @@ variable "landing_zones" {
       description                                = optional(string)
     })))
     additional_vnet_address_space = optional(list(string), [])
-    additional_subnets = optional(map(object({
-      name              = string
-      address_space     = list(string)
+    additional_subnets = map(object({
+      name_override     = optional(string)
+      address_prefixes  = list(string)
       service_endpoints = optional(list(string), [])
-      delegations = optional(list(object({
-        name         = string
-        service_name = string
-      })), [])
-    })), {})
+      delegations = optional(map(object({
+        service_name = string,
+        actions      = optional(list(string), [])
+      })))
+    }))
   }))
 }
 

--- a/components/landing/inputs-required.tf
+++ b/components/landing/inputs-required.tf
@@ -62,7 +62,7 @@ variable "landing_zones" {
     additional_vnet_address_space = optional(list(string), [])
     additional_subnets = optional(map(object({
       name_override     = optional(string)
-      address_prefixes  = list(string)
+      address_prefixes  = optional(list(string))
       service_endpoints = optional(list(string), [])
       delegations = optional(map(object({
         service_name = string,

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -104,11 +104,13 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.8.0/24"]
     additional_subnets = {
-      name_override    = "ingest00-aria-migration-sbox"
-      address_prefixes = ["10.247.8.0/27"]
-      delegations = {
-        service_name = "Microsoft.Storage/storageAccounts"
-        actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
+      ingest00-aria-migration-sbox = {
+        name_override    = "ingest00-aria-migration-sbox"
+        address_prefixes = ["10.247.8.0/27"]
+        delegations = {
+          service_name = "Microsoft.Storage/storageAccounts"
+          actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
+        }
       }
     }
 
@@ -181,11 +183,13 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.7.0/24"]
     additional_subnets = {
-      name_override    = "ingest01-aria-migration-sbox"
-      address_prefixes = ["10.247.7.0/27"]
-      delegations = {
-        service_name = "Microsoft.Storage/storageAccounts"
-        actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
+      ingest01-aria-migration-sbox = {
+        name_override    = "ingest01-aria-migration-sbox"
+        address_prefixes = ["10.247.7.0/27"]
+        delegations = {
+          service_name = "Microsoft.Storage/storageAccounts"
+          actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
+        }
       }
     }
 

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -104,7 +104,7 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.8.0/24"]
     additional_subnets = {
-      name_override    = "ingest00-aria-migration-${var.env}"
+      name_override    = "ingest00-aria-migration-sbox"
       address_prefixes = ["10.247.8.0/27"]
       delegations = {
         service_name = "Microsoft.Storage/storageAccounts"
@@ -181,7 +181,7 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.7.0/24"]
     additional_subnets = {
-      service_name     = "ingest01-aria-migration-${var.env}"
+      name_override    = "ingest01-aria-migration-sbox"
       address_prefixes = ["10.247.7.0/27"]
       delegations = {
         service_name = "Microsoft.Storage/storageAccounts"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -101,6 +101,14 @@ landing_zones = {
         roles = ["Owner", "Storage Blob Data Owner"]
       }
     ]
+
+    additional_vnet_address_space = ["10.247.8.0/24"]
+    additional_subnets = {
+      "private-endpoints" = {
+        address_prefixes = ["10.247.8.0/27"]
+      }
+    }
+    
     gh_runners = {
       "dlrm-ingestionengine" = {
         deploy            = true
@@ -167,6 +175,13 @@ landing_zones = {
         roles = ["Owner", "Storage Blob Data Owner"]
       }
     ]
+
+    additional_vnet_address_space = ["10.247.7.0/24"]
+    additional_subnets = {
+      "private-endpoints" = {
+        address_prefixes = ["10.247.7.0/27"]
+      }
+    }
     gh_runners = {
       "dlrm-ingestionengine" = {
         deploy            = true

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -104,11 +104,14 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.8.0/24"]
     additional_subnets = {
-      "ingest00-aria-migration-${var.env}" = {
-        address_prefixes = ["10.247.8.0/27"]
+      name_override    = "ingest00-aria-migration-${var.env}"
+      address_prefixes = ["10.247.8.0/27"]
+      delegations = {
+        service_name = "Microsoft.Storage/storageAccounts"
+        actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
       }
     }
-    
+
     gh_runners = {
       "dlrm-ingestionengine" = {
         deploy            = true
@@ -178,10 +181,14 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.7.0/24"]
     additional_subnets = {
-      "ingest01-aria-migration-${var.env}" = {
-        address_prefixes = ["10.247.7.0/27"]
+      service_name     = "ingest01-aria-migration-${var.env}"
+      address_prefixes = ["10.247.7.0/27"]
+      delegations = {
+        service_name = "Microsoft.Storage/storageAccounts"
+        actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
       }
     }
+
     gh_runners = {
       "dlrm-ingestionengine" = {
         deploy            = true

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -104,7 +104,7 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.8.0/24"]
     additional_subnets = {
-      "private-endpoints" = {
+      "ingest00-aria-migration-${var.env}" = {
         address_prefixes = ["10.247.8.0/27"]
       }
     }
@@ -178,7 +178,7 @@ landing_zones = {
 
     additional_vnet_address_space = ["10.247.7.0/24"]
     additional_subnets = {
-      "private-endpoints" = {
+      "ingest01-aria-migration-${var.env}" = {
         address_prefixes = ["10.247.7.0/27"]
       }
     }


### PR DESCRIPTION
### Jira link

See [DTSPO-24907](https://tools.hmcts.net/jira/browse/DTSPO-24907)

### Change description

Adding additional vnet address space and subnets for private endpoints
Necessary to enable changes in https://github.com/hmcts/dlrm-data-ingest-infra/pull/76

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
