### PR TITLE
DTSPO-24907 - Ensure sa is public

### DIFF
--- a/components/ai/storage.tf
+++ b/components/ai/storage.tf
@@ -9,6 +9,7 @@ module "storage" {
   common_tags                   = module.common_tags.common_tags
   private_endpoint_subnet_id    = data.azurerm_subnet.private_endpoint_subnet.id
   public_network_access_enabled = true
+  default_action                = "Allow"
 }
 
 module "common_tags" {

--- a/components/ai/storage.tf
+++ b/components/ai/storage.tf
@@ -9,8 +9,6 @@ module "storage" {
   common_tags                   = module.common_tags.common_tags
   private_endpoint_subnet_id    = data.azurerm_subnet.private_endpoint_subnet.id
   public_network_access_enabled = true
-  ip_rules                      = var.ip_rules
-  sa_subnets                    = [data.azurerm_subnet.azure_devops_agent_subnet.id]
 }
 
 module "common_tags" {


### PR DESCRIPTION
### Jira link

See [DTSPO-24907](https://tools.hmcts.net/jira/browse/DTSPO-24907)

### Change description

Ensure storage account for AI services has network set to public

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
